### PR TITLE
Added a folder for stan scaffolds (simple stan files used to test and…

### DIFF
--- a/inst/stan_scaffolds/macro_hs.stan
+++ b/inst/stan_scaffolds/macro_hs.stan
@@ -1,0 +1,27 @@
+// Horseshoe prior example
+// Required macros:
+  // hs_betas (stan_macro_horseshoe)
+functions{
+  $ hs_betas$functions
+}
+data {
+  int N;
+  int D;
+  matrix[N,D] x;
+  vector[N] y;
+  $ hs_betas$data
+}
+parameters {
+  real<lower=0> sigma;
+  real alpha;
+  $ hs_betas$parms
+}
+transformed parameters {
+  $ hs_betas$tparms
+}
+model {
+  vector[N] eta = alpha + x * {{ hs_betas$coef }} ;
+  $ hs_betas$prior
+
+  target += normal_lpdf(y | eta, sigma);
+}

--- a/inst/stan_scaffolds/macro_ncp.stan
+++ b/inst/stan_scaffolds/macro_ncp.stan
@@ -1,0 +1,25 @@
+// Simple non-central parameterization example
+// Required macros:
+  // alpha_ncp (stan_macro_ncp)
+data{
+  int N;
+  int N_groups;
+  int<lower=1,upper=N_groups> group[N];
+  vector[N] y;
+}
+parameters {
+  real mu;
+  real<lower=0> sigma;
+  real<lower=0> tau;
+$ alpha_ncp$parms
+}
+transformed parameters {
+  $ alpha_ncp$tparms
+}
+model {
+  // Prior distributions
+  $ alpha_ncp$prior
+  target += student_t_lpdf([sigma, tau] | 7, 0, 5) ;
+
+  target += normal_lpdf( y | {{ alpha_ncp$name }}[group] , sigma);
+}

--- a/tests/testthat/test-macro_hs.R
+++ b/tests/testthat/test-macro_hs.R
@@ -1,28 +1,4 @@
-hs_test_code =
-"functions{
-  $ hs_betas$functions
-}
-data {
-  int N;
-  int D;
-  matrix[N,D] x;
-  vector[N] y;
-  $ hs_betas$data
-}
-parameters {
-  real<lower=0> sigma;
-  real alpha;
-  $ hs_betas$parms
-}
-transformed parameters {
-  $ hs_betas$tparms
-}
-model {
-  vector[N] eta = alpha + x * {{ hs_betas$coef }} ;
-  $ hs_betas$prior
-
-  target += normal_lpdf(y | eta, sigma);
-}"
+hs_test_code = readLines("inst/stan_scaffolds/macro_hs.stan")
 
 test_that("simple horseshoe model is syntactically correct", {
   expect_type(parse_stan_macros(

--- a/tests/testthat/test-macro_hs.R
+++ b/tests/testthat/test-macro_hs.R
@@ -1,4 +1,4 @@
-hs_test_code = readLines("inst/stan_scaffolds/macro_hs.stan")
+hs_test_code = readLines("../../inst/stan_scaffolds/macro_hs.stan")
 
 test_that("simple horseshoe model is syntactically correct", {
   expect_type(parse_stan_macros(

--- a/tests/testthat/test-macro_ncp.R
+++ b/tests/testthat/test-macro_ncp.R
@@ -1,4 +1,4 @@
-ncp_code = readLines("inst/stan_scaffolds/macro_ncp.stan")
+ncp_code = readLines("../../inst/stan_scaffolds/macro_ncp.stan")
 alpha = stan_macro_ncp("alpha", "mu", "tau", "N_groups")
 test_that("ncp macro works",{
   expect_type(parse_stan_macros(ncp_code, alpha_ncp = alpha), "character")

--- a/tests/testthat/test-macro_ncp.R
+++ b/tests/testthat/test-macro_ncp.R
@@ -1,28 +1,4 @@
-ncp_code =
-  "data{
-  int N;
-  int N_groups;
-  int<lower=1,upper=N_groups> group[N];
-  vector[N] y;
-}
-parameters {
-  real mu;
-  real<lower=0> sigma;
-  real<lower=0> tau;
-$ alpha_ncp$parms
-}
-transformed parameters {
-  $ alpha_ncp$tparms
-}
-model {
-  // Prior distributions
-  $ alpha_ncp$prior
-  target += student_t_lpdf([sigma, tau] | 7, 0, 5) ;
-
-  target += normal_lpdf( y | {{ alpha_ncp$name }}[group] , sigma);
-}
-
-"
+ncp_code = readLines("inst/stan_scaffolds/macro_ncp.stan")
 alpha = stan_macro_ncp("alpha", "mu", "tau", "N_groups")
 test_that("ncp macro works",{
   expect_type(parse_stan_macros(ncp_code, alpha_ncp = alpha), "character")


### PR DESCRIPTION
Stan scaffolds (stan models with macro insertions used for testing) are now separate files instead of text vectors; this will allow greater code re-use within the project.