### PR TITLE
Standardize marco sections

### DIFF
--- a/R/define_stan_macro.r
+++ b/R/define_stan_macro.r
@@ -3,37 +3,34 @@
 #' @param coef name of the "end-product" created by the macro, to be used elsewhere in the stan code
 #' @param functions functions block
 #' @param data data block
-#' @param transformed_data_1 declarations in transformed data block
-#' @param transformed_data_2 after declarations transformed data block
-#' @param parameters parameters block
-#' @param transformed_parameters_1 declarations in transformed parameters block
-#' @param transformed_parameters_2 after declarations in transformed parameters block
+#' @param td1 declarations in transformed data block
+#' @param td2 after declarations transformed data block
+#' @param parms parameters block
+#' @param tp1 declarations in transformed parameters block
+#' @param tp2 after declarations in transformed parameters block
 #' @param model_decl local declarations in model block
 #' @param prior prior distributions in model block
 #' @param likelihood likelihood statements in model block
-#' @param generated_quantities_1 declarations in generated quantities block
-#' @param generated_quantities_2 after declarations in generated quantities block
+#' @param gq1 declarations in generated quantities block
+#' @param gq2 after declarations in generated quantities block
 #' @param ... named character vectors defining extra sections of the macro; these will be used with `glue`
 #' @param .glue_control named list of control args for glue
 #' @return a function that with arguments .section, ..., and whatever is in .args
 #' @export
 define_stan_macro = function(.args = alist(), coef = "", functions = "", data = "",
-                             transformed_data_1 = "", transformed_data_2 = "",
-                             parameters = "",transformed_parameters_1 = "",
-                             transformed_parameters_2 = "", model_decl = "",
-                             prior = "", likelihood = "",generated_quantities_1 = "",
-                             generated_quantities_2 = "", ...,
+                             td1 = "", td2 = "", parms = "",tp1 = "",
+                             tp2 = "", model_decl = "", prior = "", likelihood = "",
+                             gq1 = "", gq2 = "", ...,
                              .glue_control = list(.open = "{{", .close = "}}")) {
   sections = list(functions = functions, coef = coef, data = data,
-                  transformed_data_1=transformed_data_1, td1 = transformed_data_1,
-                  transformed_data_2=transformed_data_2, td2 = transformed_data_2,
-                  parameters = parameters, parms = parameters,
-                  transformed_parameters_1 = transformed_parameters_1, tp1 = transformed_parameters_1,
-                  transformed_parameters_2 = transformed_parameters_2, tp2 = transformed_parameters_2,
+                  transformed_data_1=td1, td1 = td1,
+                  transformed_data_2=td2, td2 = td2,
+                  parameters = parms, parms = parms,
+                  transformed_parameters_1 = tp1, tp1 = tp1,
+                  transformed_parameters_2 = tp2, tp2 = tp2,
                   model_decl = model_decl, prior = prior, likelihood = likelihood, like = likelihood,
-                  generated_quantities_1 = generated_quantities_1, gq1 = generated_quantities_1,
-                  generated_quantities_2 = generated_quantities_2, gq2 = generated_quantities_2,
-                  ...)
+                  generated_quantities_1 = gq1, gq1 = gq1,
+                  generated_quantities_2 = gq2, gq2 = gq2, ...)
   sec_names = force(c(".all", force(names(sections))))
   .args_full = c(.args, alist(...=, .section = sec_names))
 

--- a/R/define_stan_macro.r
+++ b/R/define_stan_macro.r
@@ -1,12 +1,39 @@
 #' define_stan_macro: create a function that makes stan macros convienient
 #' @param .args alist of argument names that must be subbed
-#' @param ... named character vectors defining a section of the macro; these will be used with `glue`
+#' @param coef name of the "end-product" created by the macro, to be used elsewhere in the stan code
+#' @param functions functions block
+#' @param data data block
+#' @param transformed_data_1 declarations in transformed data block
+#' @param transformed_data_2 after declarations transformed data block
+#' @param parameters parameters block
+#' @param transformed_parameters_1 declarations in transformed parameters block
+#' @param transformed_parameters_2 after declarations in transformed parameters block
+#' @param model_decl local declarations in model block
+#' @param prior prior distributions in model block
+#' @param likelihood likelihood statements in model block
+#' @param generated_quantities_1 declarations in generated quantities block
+#' @param generated_quantities_2 after declarations in generated quantities block
+#' @param ... named character vectors defining extra sections of the macro; these will be used with `glue`
 #' @param .glue_control named list of control args for glue
 #' @return a function that with arguments .section, ..., and whatever is in .args
 #' @export
-define_stan_macro = function(.args = alist(), ...,
+define_stan_macro = function(.args = alist(), coef = "", functions = "", data = "",
+                             transformed_data_1 = "", transformed_data_2 = "",
+                             parameters = "",transformed_parameters_1 = "",
+                             transformed_parameters_2 = "", model_decl = "",
+                             prior = "", likelihood = "",generated_quantities_1 = "",
+                             generated_quantities_2 = "", ...,
                              .glue_control = list(.open = "{{", .close = "}}")) {
-  sections = list(...)
+  sections = list(functions = functions, coef = coef, data = data,
+                  transformed_data_1=transformed_data_1, td1 = transformed_data_1,
+                  transformed_data_2=transformed_data_2, td2 = transformed_data_2,
+                  parameters = parameters, parms = parameters,
+                  transformed_parameters_1 = transformed_parameters_1, tp1 = transformed_parameters_1,
+                  transformed_parameters_2 = transformed_parameters_2, tp2 = transformed_parameters_2,
+                  model_decl = model_decl, prior = prior, likelihood = likelihood, like = likelihood,
+                  generated_quantities_1 = generated_quantities_1, gq1 = generated_quantities_1,
+                  generated_quantities_2 = generated_quantities_2, gq2 = generated_quantities_2,
+                  ...)
   sec_names = force(c(".all", force(names(sections))))
   .args_full = c(.args, alist(...=, .section = sec_names))
 

--- a/R/macro_hs.R
+++ b/R/macro_hs.R
@@ -23,7 +23,7 @@ stan_macro_horseshoe = define_stan_macro(
   real<lower=0> hs_df_slab_{{name}};  // slab degrees of freedom
   real<lower=0> hs_scale_global_{{name}};  // global prior scale
   real<lower=0> hs_scale_slab_{{name}};  // slab prior scale",
-  parms = "  // horseshoe shrinkage parameters, global
+  parameters = "  // horseshoe shrinkage parameters, global
   real<lower=0> hs_global_{{name}}[2];  // global shrinkage parameters
   real<lower=0> hs_c2_{{name}};  // slab regularization parameter
   // local parameters for horseshoe
@@ -39,9 +39,9 @@ stan_macro_horseshoe = define_stan_macro(
             std_normal_lpdf(hs_local_{{name}}[1]) -  {{N_local}} * log(0.5) +
             inv_gamma_lpdf(hs_local_{{name}}[2] |
                0.5 * hs_df_{{name}}, 0.5 * hs_df_{{name}});",
-  coefs = "b_{{name}}",
+  coef = "b_{{name}}",
   # WHAT IS ncoef?????
-  tparms = glue_args(" // horseshoe regression coefs
+  transformed_parameters_1 = glue_args(" // horseshoe regression coefs
   vector[{{N_local}}] b_{{name}} = horseshoe({{hs_args}});",
      N_local = "{{N_local}}", name = "{{name}}",
      hs_args = paste("hs_z_{{name}}, hs_local_{{name}}",

--- a/R/macro_ncp.R
+++ b/R/macro_ncp.R
@@ -1,11 +1,11 @@
 #' @export
 stan_macro_ncp = define_stan_macro(
   .args = alist(name="alpha", mu ="mu", sd ="tau", size ="N_groups"),
-  parms = "// Non-central parameterization of {{name}}
+  parameters = "// Non-central parameterization of {{name}}
   vector[{{size}}] {{name}}_z;",
-  tparms = "// Non-central parameterization of {{name}}
+  transformed_parameters_1 = "// Non-central parameterization of {{name}}
   vector[{{size}}] {{name}} = {{name}}_z * {{sd}} + {{mu}};",
   prior = "// Non-central parameterization of {{name}}
   target += std_normal_lpdf({{name}}_z);",
-  name = "{{name}}"
+  coef = "{{name}}"
 )

--- a/R/macro_ncp.R
+++ b/R/macro_ncp.R
@@ -1,11 +1,11 @@
 #' @export
 stan_macro_ncp = define_stan_macro(
   .args = alist(name="alpha", mu ="mu", sd ="tau", size ="N_groups"),
-  parameters = "// Non-central parameterization of {{name}}
+  coef = "{{name}}",
+  parms = "// Non-central parameterization of {{name}}
   vector[{{size}}] {{name}}_z;",
-  transformed_parameters_1 = "// Non-central parameterization of {{name}}
+  tp1 = "// Non-central parameterization of {{name}}
   vector[{{size}}] {{name}} = {{name}}_z * {{sd}} + {{mu}};",
   prior = "// Non-central parameterization of {{name}}
-  target += std_normal_lpdf({{name}}_z);",
-  coef = "{{name}}"
+  target += std_normal_lpdf({{name}}_z);"
 )

--- a/inst/stan_scaffolds/macro_hs.stan
+++ b/inst/stan_scaffolds/macro_hs.stan
@@ -17,7 +17,7 @@ parameters {
   $ hs_betas$parms
 }
 transformed parameters {
-  $ hs_betas$tparms
+  $ hs_betas$tp1
 }
 model {
   vector[N] eta = alpha + x * {{ hs_betas$coef }} ;

--- a/inst/stan_scaffolds/macro_ncp.stan
+++ b/inst/stan_scaffolds/macro_ncp.stan
@@ -14,12 +14,12 @@ parameters {
 $ alpha_ncp$parms
 }
 transformed parameters {
-  $ alpha_ncp$tparms
+  $ alpha_ncp$tp1
 }
 model {
   // Prior distributions
   $ alpha_ncp$prior
   target += student_t_lpdf([sigma, tau] | 7, 0, 5) ;
 
-  target += normal_lpdf( y | {{ alpha_ncp$name }}[group] , sigma);
+  target += normal_lpdf( y | {{ alpha_ncp$coef }}[group] , sigma);
 }

--- a/tests/testthat/test-macro_hs.R
+++ b/tests/testthat/test-macro_hs.R
@@ -1,4 +1,5 @@
-hs_test_code = readLines("../../inst/stan_scaffolds/macro_hs.stan")
+wd = "../.."
+hs_test_code = readLines(file.path(wd, "inst/stan_scaffolds/macro_hs.stan"))
 
 test_that("simple horseshoe model is syntactically correct", {
   expect_type(parse_stan_macros(

--- a/tests/testthat/test-macro_ncp.R
+++ b/tests/testthat/test-macro_ncp.R
@@ -1,4 +1,5 @@
-ncp_code = readLines("../../inst/stan_scaffolds/macro_ncp.stan")
+wd = "../.."
+ncp_code = readLines(file.path(wd, "inst/stan_scaffolds/macro_ncp.stan"))
 alpha = stan_macro_ncp("alpha", "mu", "tau", "N_groups")
 test_that("ncp macro works",{
   expect_type(parse_stan_macros(ncp_code, alpha_ncp = alpha), "character")


### PR DESCRIPTION
`define_stan_macro` now has standard arguments for sections, with some built-in aliases.